### PR TITLE
Update: add event type

### DIFF
--- a/assets/content/documentation/H2d/Events-and-Interactivity.md
+++ b/assets/content/documentation/H2d/Events-and-Interactivity.md
@@ -38,7 +38,7 @@ Don't forget to remove the event using removeEventTarget when disposing your obj
 Keyboard events can be observed using the global event, check if the `event.kind` is `EKeyDown` or `EKeyUp`.
 
 ```haxe
-function onEvent(event) {
+function onEvent(event : hxd.Event) {
 	switch(event.kind) {
 		case EKeyDown: trace('DOWN keyCode: ${event.keyCode}, charCode: ${event.charCode}');
 		case EKeyUp: trace('UP keyCode: ${event.keyCode}, charCode: ${event.charCode}');


### PR DESCRIPTION
Without the type, compilation fails for me with this error:

```shell
Main.hx:31: characters 48-55 : event : { kind : Unknown<0>, keyCode : String, charCode : String } -> Void shouldbe hxd.Event -> Void
Main.hx:31: characters 48-55 : Cannot unify argument 1
```

```shell
❯ haxe --version
4.0.0-preview.4+1e3e5e0
```

Sources:
* http://heaps.io/documentation/h2d/events-and-interactivity.html