### PR TITLE
Add missing resources loading in code snippet

### DIFF
--- a/assets/content/documentation/H2d/Displaying-Text.md
+++ b/assets/content/documentation/H2d/Displaying-Text.md
@@ -6,6 +6,9 @@ It's also possible to get the size of the text with textWidth/textHeight.
 ### Use text in Heaps
 
 ```haxe
+// Initialize the Resources loader
+hxd.Res.initEmbed();
+
 var tf = new h2d.Text(hxd.Res.fonts.myFontName.toFont());
 tf.text = "Hello World\nHeaps is great!";
 tf.textAlign = Center;


### PR DESCRIPTION
The code snippet was missing the resources loading initialization, making first line producing `Null access` when resources were correctly setup.