### PR TITLE
Missing package name `hxd` on Res usage

### DIFF
--- a/assets/content/documentation/H2d/Drawing-Tiles.md
+++ b/assets/content/documentation/H2d/Drawing-Tiles.md
@@ -16,7 +16,7 @@ class Main extends hxd.App {
 		super.init();
 		
 		// parse Tiled json file
-		var mapData:TiledMapData = haxe.Json.parse(Res.tiles_json.entry.getText());
+		var mapData:TiledMapData = haxe.Json.parse(hxd.Res.tiles_json.entry.getText());
 		
 		// get tile image (tiles.png) from resources
 		var tileImage  = hxd.Res.tiles_png.toTile();


### PR DESCRIPTION
Code doesn't work out of the box without that.

Sources:
* http://heaps.io/documentation/h2d/drawing-tiles.html