### PR TITLE
Better link for HXSL

### DIFF
--- a/assets/content/index.mtt
+++ b/assets/content/index.mtt
@@ -207,7 +207,7 @@
 			<li><a href="documentation/h2d">h2d</a> used for 2D display (for 2D games and user interfaces)</li>
 			<li><a href="documentation/h3d">h3d</a> used for rendering 3D models</li>
 			<li><a href="documentation/hxd">hxd</a> contains cross platform classes and a complete resource loading and management framework</li>
-			<li><a href="documentation/shaders">hxsl</a> is the Heaps Shader Language implementation</li>
+			<li><a href="documentation/hxsl">hxsl</a> is the Haxe Shader Language implementation</li>
 		</ul>
 	</div>
 </section>


### PR DESCRIPTION
The current link labeled **hxsl**:
![image](https://user-images.githubusercontent.com/2192439/47174742-b5cce480-d2ce-11e8-882f-940109455719.png)

opens the **Shaders page**, which is basically empty except for another link to better HXSL docs:

![image](https://user-images.githubusercontent.com/2192439/47174773-ced59580-d2ce-11e8-821e-54eb885d2f34.png)

Seems better to link straight to the HXSL docs, since that's what you clicked on in the first place. Also, title it to match the hxsl docs page.

Perhaps revisit both the copy and the link once the Shaders top-level page has been flushed out more?