### PR TITLE
Add spacing in File formats support description

### DIFF
--- a/assets/content/index.mtt
+++ b/assets/content/index.mtt
@@ -115,7 +115,7 @@
 			<div class="col-4">
 				<img src="img/feather/image.svg"/>
 				<h3>File formats support</h3>
-				<p>PNG,JPG,FBX,OGG,etc.</p>
+				<p>PNG, JPG, FBX, OGG, etc.</p>
 			</div>
 
 			<div class="col-4">


### PR DESCRIPTION
There are no spaces after commas in the File formats support description, this pull request fixes that.