### PR TITLE
Update highlighter library

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,10 +20,6 @@ jobs:
         with:
           submodules: true
 
-      # we are using this version in order to build vscode-textmate
-      - name: Setup Node
-        uses: actions/setup-node@v1
-
       - name: Setup Haxe
         uses: krdlab/setup-haxe@v1
         with:

--- a/heaps.io.hxml
+++ b/heaps.io.hxml
@@ -26,7 +26,7 @@
  --next
 -main SyntaxHighlighter
 -lib markdown
--lib highlighter:0.6.1
+-lib highlighter
 -lib tink_template
 -cp src
 --macro tink.Template.addFlavor('html', '::', '::', false)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,39 +1,42 @@
 {
     "name": "heaps-website",
     "version": "0.1.0",
-    "lockfileVersion": 1,
+    "lockfileVersion": 2,
     "requires": true,
-    "dependencies": {
-        "fast-plist": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/fast-plist/-/fast-plist-0.1.2.tgz",
-            "integrity": "sha1-pFr/NFGWAG1AbKbNzQX2kFHvNbg=",
-            "dev": true
-        },
-        "nan": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-            "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-            "dev": true
-        },
-        "oniguruma": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-6.2.1.tgz",
-            "integrity": "sha1-pQ7mlkKEStHSUmhaqxhxcbBuzgQ=",
-            "dev": true,
-            "requires": {
-                "nan": "2.10.0"
+    "packages": {
+        "": {
+            "name": "heaps-website",
+            "version": "0.1.0",
+            "devDependencies": {
+                "vscode-oniguruma": "^2.0.1",
+                "vscode-textmate": "^9.1.0"
             }
+        },
+        "node_modules/vscode-oniguruma": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-2.0.1.tgz",
+            "integrity": "sha512-poJU8iHIWnC3vgphJnrLZyI3YdqRlR27xzqDmpPXYzA93R4Gk8z7T6oqDzDoHjoikA2aS82crdXFkjELCdJsjQ==",
+            "dev": true
+        },
+        "node_modules/vscode-textmate": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-9.1.0.tgz",
+            "integrity": "sha512-lxKSVp2DkFOx9RDAvpiYUrB9/KT1fAfi1aE8CBGstP8N7rLF+Seifj8kDA198X0mYj1CjQUC+81+nQf8CO0nVA==",
+            "dev": true
+        }
+    },
+    "dependencies": {
+        "vscode-oniguruma": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-2.0.1.tgz",
+            "integrity": "sha512-poJU8iHIWnC3vgphJnrLZyI3YdqRlR27xzqDmpPXYzA93R4Gk8z7T6oqDzDoHjoikA2aS82crdXFkjELCdJsjQ==",
+            "dev": true
         },
         "vscode-textmate": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-3.1.5.tgz",
-            "integrity": "sha1-G4mfwBPzOygr8asFFXwbWRD1vus=",
-            "dev": true,
-            "requires": {
-                "fast-plist": "0.1.2",
-                "oniguruma": "6.2.1"
-            }
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-9.1.0.tgz",
+            "integrity": "sha512-lxKSVp2DkFOx9RDAvpiYUrB9/KT1fAfi1aE8CBGstP8N7rLF+Seifj8kDA198X0mYj1CjQUC+81+nQf8CO0nVA==",
+            "dev": true
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "heaps-website",
     "version": "0.1.0",
     "devDependencies": {
-        "vscode-textmate": "3.1.5"
+        "vscode-oniguruma": "^2.0.1",
+        "vscode-textmate": "^9.1.0"
     }
 }

--- a/src/SyntaxHighlighter.hx
+++ b/src/SyntaxHighlighter.hx
@@ -7,40 +7,37 @@ class SyntaxHighlighter
 	public static function patch () {
 		Sys.println("Applying syntax highlighting ...");
 
-		var haxeGrammar = new Highlighter("grammars/haxe-TmLanguage/haxe.tmLanguage");
-		var hxmlGrammar = new Highlighter("grammars/haxe-TmLanguage/hxml.tmLanguage");
-		var htmlGrammar = new Highlighter("grammars/html.tmbundle/Syntaxes/HTML.plist");
-
-		var grammars = [
-			"haxe" => haxeGrammar,
-			"hxml" => hxmlGrammar,
-			"html" => htmlGrammar,
+		var grammarFiles = [
+			"haxe" => "grammars/haxe-TmLanguage/haxe.tmLanguage",
+			"hxml" => "grammars/haxe-TmLanguage/hxml.tmLanguage",
+			"html" => "grammars/html.tmbundle/Syntaxes/HTML.plist",
 		];
 
-		// Go over the generated HTML file and apply syntax highlighting
-		var missingGrammars = Highlighter.patchFolder("output/documentation", grammars, function (classList) {
-			return classList.substr(12);
+		Highlighter.loadHighlighters(grammarFiles, function(highlighters) {
+			// Go over the generated HTML file and apply syntax highlighting
+			var missingGrammars = Highlighter.patchFolder("output/documentation", highlighters, function(classList) {
+				return classList.substr(12);
+			});
+
+			for (g in missingGrammars) {
+				Sys.println('Missing grammar for "${g}"');
+			}
+
+			// Go over the generated HTML file and apply syntax highlighting
+			missingGrammars = Highlighter.patchFolder("output/samples", highlighters, function(classList) {
+				return classList.substr(12);
+			});
+
+			for (g in missingGrammars) {
+				Sys.println('Missing grammar for "${g}"');
+			}
+
+			// Add CSS rules for highlighting
+			var path = "output/css/styles.min.css";
+			var baseStyle = File.getContent(path);
+			var syntaxStyle = highlighters["haxe"].runCss();
+			File.saveContent(path, baseStyle + syntaxStyle);
 		});
-
-		for (g in missingGrammars) {
-			Sys.println('Missing grammar for "${g}"');
-		}
-
-		// Go over the generated HTML file and apply syntax highlighting
-		missingGrammars = Highlighter.patchFolder("output/samples", grammars, function (classList) {
-			return classList.substr(12);
-		});
-
-		for (g in missingGrammars) {
-			Sys.println('Missing grammar for "${g}"');
-		}
-
-
-		// Add CSS rules for highlighting
-		var path = "output/css/styles.min.css";
-		var baseStyle = File.getContent(path);
-		var syntaxStyle = haxeGrammar.runCss();
-		File.saveContent(path, baseStyle + syntaxStyle);
 	}
 
 	public static function main(){


### PR DESCRIPTION
Update the highlighter library so we can finally stop depending on an ancient version of nodejs.

See https://github.com/ibilon/Highlighter/pull/5.