### PR TITLE
Fix docs sidebar generation

### DIFF
--- a/src/util/MarkdownListParser.hx
+++ b/src/util/MarkdownListParser.hx
@@ -54,7 +54,6 @@ class MarkdownListParser {
 							}
 						case _:
 					}
-					prevIndent = indent;
 				} else {
 					// TODO: support going back more than one indentation level
 					if (indent < prevIndent) {
@@ -73,9 +72,9 @@ class MarkdownListParser {
 							links.push(link);
 						case _:
 					}
-					prevIndent = indent;
-					prevLink = link;
 				}
+				prevIndent = indent;
+				prevLink = link;
 			}
 		}
 		return toplevel;


### PR DESCRIPTION
This was being generated incorrectly due to the missing `prevLink = link;` line:

```md
* [[ link 1 ]]
  * [[ link 2 ]]
     * [[ link 3 ]]
```

For example, with:
```md
* [[Sample games for learning]]
  * [[Copy & paste game templates]]
    * [[Breakout]]
    * [[Platform game]]
    * [[Rogue]]
```

Before:
![image](https://github.com/user-attachments/assets/63340c5c-218a-4a45-be4c-0bddec883847)

After:
![image](https://github.com/user-attachments/assets/c03361d2-957b-40f2-bf29-7feee7e86ad1)


